### PR TITLE
Support resubscribing a user to a single opt-in list.

### DIFF
--- a/public/partials/shortcodes/process/process_form_submission.php
+++ b/public/partials/shortcodes/process/process_form_submission.php
@@ -177,8 +177,12 @@ if ( is_wp_error( $member_exists ) || $double_optin_resubscribe === true ) {
 	// Check the opt-in value - is it double or single?
 	// Double opt-in means 'status_if_new' => 'pending'
 	$double_optin = isset( $optin_settings['optin'] ) ? (int) $optin_settings['optin'] : 0;
+        $was_unsubscribed = isset($member_exists['status']) && $member_exists['status'] == 'unsubscribed';
 
-	if ( $double_optin === 1 ) {
+        // If the user was unsubscribed and is re-subscribing, we set the status to 'pending', which
+        // causes Mailchimp to send them a confirmation email.  This is the only way Mailchimp will
+        // allow us to re-subscribe the user.
+	if ( $double_optin === 1 || $was_unsubscribed) {
 
 		// Double opt-in
 		$member_data['status_if_new'] = 'pending';

--- a/public/partials/shortcodes/process/process_form_submission.php
+++ b/public/partials/shortcodes/process/process_form_submission.php
@@ -177,11 +177,12 @@ if ( is_wp_error( $member_exists ) || $double_optin_resubscribe === true ) {
 	// Check the opt-in value - is it double or single?
 	// Double opt-in means 'status_if_new' => 'pending'
 	$double_optin = isset( $optin_settings['optin'] ) ? (int) $optin_settings['optin'] : 0;
-        $was_unsubscribed = isset($member_exists['status']) && $member_exists['status'] == 'unsubscribed';
 
-        // If the user was unsubscribed and is re-subscribing, we set the status to 'pending', which
-        // causes Mailchimp to send them a confirmation email.  This is the only way Mailchimp will
-        // allow us to re-subscribe the user.
+	// If the user was unsubscribed and is re-subscribing, we set the status to 'pending', which
+	// causes Mailchimp to send them a confirmation email.  This is the only way Mailchimp will
+	// allow us to re-subscribe the user.
+	$was_unsubscribed = isset($member_exists['status']) && $member_exists['status'] == 'unsubscribed';
+
 	if ( $double_optin === 1 || $was_unsubscribed) {
 
 		// Double opt-in

--- a/public/partials/shortcodes/process/process_form_submission_ajax.php
+++ b/public/partials/shortcodes/process/process_form_submission_ajax.php
@@ -140,8 +140,12 @@ if ( is_wp_error( $member_exists ) || $double_optin_resubscribe === true ) {
 	// Check the opt-in value - is it double or single?
 	// Double opt-in means 'status_if_new' => 'pending'
 	$double_optin = isset( $optin_settings['optin'] ) ? (int) $optin_settings['optin'] : 0;
+        $was_unsubscribed = isset($member_exists['status']) && $member_exists['status'] == 'unsubscribed';
 
-	if ( $double_optin === 1 ) {
+        // If the user was unsubscribed and is re-subscribing, we set the status to 'pending', which
+        // causes Mailchimp to send them a confirmation email.  This is the only way Mailchimp will
+        // allow us to re-subscribe the user.
+	if ( $double_optin === 1 || $was_unsubscribed) {
 
 		// Double opt-in
 		$member_data['status_if_new'] = 'pending';

--- a/public/partials/shortcodes/process/process_form_submission_ajax.php
+++ b/public/partials/shortcodes/process/process_form_submission_ajax.php
@@ -140,11 +140,12 @@ if ( is_wp_error( $member_exists ) || $double_optin_resubscribe === true ) {
 	// Check the opt-in value - is it double or single?
 	// Double opt-in means 'status_if_new' => 'pending'
 	$double_optin = isset( $optin_settings['optin'] ) ? (int) $optin_settings['optin'] : 0;
-        $was_unsubscribed = isset($member_exists['status']) && $member_exists['status'] == 'unsubscribed';
 
-        // If the user was unsubscribed and is re-subscribing, we set the status to 'pending', which
-        // causes Mailchimp to send them a confirmation email.  This is the only way Mailchimp will
-        // allow us to re-subscribe the user.
+	// If the user was unsubscribed and is re-subscribing, we set the status to 'pending', which
+	// causes Mailchimp to send them a confirmation email.  This is the only way Mailchimp will
+	// allow us to re-subscribe the user.
+	$was_unsubscribed = isset( $member_exists['status'] ) && $member_exists['status'] == 'unsubscribed';
+
 	if ( $double_optin === 1 || $was_unsubscribed) {
 
 		// Double opt-in


### PR DESCRIPTION
Kudos to you for your work on this plugin.

I'm submitting this fix for an edge case I discovered in testing.  This is the scenario:
- the list is single opt-in
- a user was on the list previously, then unsubscribed
- now they wish to re-subscribe

In this case I was getting a "member compliance error" when they tried to re-subscribe.  The only way to get Mailchimp to re-subscribe them is to set their status to 'pending', which causes Mailchimp to send them a confirmation by email.
 