### PR TITLE
[BUG] Filetime never updated in register script.

### DIFF
--- a/blocks/easy-forms-block/easy-forms-block.php
+++ b/blocks/easy-forms-block/easy-forms-block.php
@@ -42,7 +42,7 @@ class YIKES_Easy_Form_Block extends YIKES_Easy_Forms_Blocks {
 		wp_enqueue_style( 'yikes-datepicker-styles', YIKES_MC_URL . 'public/css/yikes-datepicker-styles.min.css', array(), YIKES_MC_VERSION );
 		wp_enqueue_style( 'yikes-easy-forms-blocks-css', YIKES_MC_URL . 'blocks/easy-forms-block/build/style.css', array(), YIKES_MC_VERSION );
 
-		wp_register_script( 'yikes-easy-forms-blocks', YIKES_MC_URL . 'blocks/easy-forms-block/build/easy-forms-blocks.js', array( 'wp-i18n', 'wp-element', 'wp-blocks', 'wp-components', 'wp-api' ), filemtime( YIKES_MC_PATH . 'blocks/easy-forms-block/easy-forms-block.js' ), true );
+		wp_register_script( 'yikes-easy-forms-blocks', YIKES_MC_URL . 'blocks/easy-forms-block/build/easy-forms-blocks.js', array( 'wp-i18n', 'wp-element', 'wp-blocks', 'wp-components', 'wp-api' ), time(), true );
 		wp_localize_script( 'yikes-easy-forms-blocks', 'ez_forms_gb_data', array(
 			'ajax_url'              => esc_url_raw( admin_url( 'admin-ajax.php' ) ),
 			'fetch_form_nonce'      => wp_create_nonce( 'fetch_form_nonce' ),


### PR DESCRIPTION
Filetime was being used with a path to the old js filenaming conventions. I changed this to just use the time function as the version so we're always getting the latest version of the script.