### PR TITLE
Update Travis CI config, Introduce PHPCS checks

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Coding Standards based custom ruleset for your plugin">
+	<description>Generally-applicable sniffs for WordPress plugins.</description>
+
+	<!-- What to scan -->
+	<file>.</file>
+	<exclude-pattern>/vendor/</exclude-pattern>
+	<exclude-pattern>/node_modules/</exclude-pattern>
+
+	<!-- How to scan -->
+	<!-- Usage instructions: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
+	<!-- Annotated ruleset: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
+	<arg value="sp"/> <!-- Show sniff and progress -->
+	<arg name="basepath" value="./"/><!-- Strip the file paths down to the relevant bit -->
+	<arg name="colors"/>
+	<arg name="extensions" value="php"/>
+	<arg name="parallel" value="8"/><!-- Enables parallel processing when available for faster results. -->
+
+	<!-- Rules: Check PHP version compatibility -->
+	<!-- https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
+	<config name="testVersion" value="5.3-"/>
+	<!-- https://github.com/PHPCompatibility/PHPCompatibilityWP -->
+	<rule ref="PHPCompatibilityWP"/>
+
+	<!-- Rules: WordPress Coding Standards -->
+	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
+	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
+	<config name="minimum_supported_wp_version" value="4.6"/>
+	<rule ref="WordPress">
+		<exclude name="WordPress.VIP"/>
+	</rule>
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<!-- Value: replace the function, class, and variable prefixes used. Separate multiple prefixes with a comma. -->
+			<property name="prefixes" type="array" value="my-plugin"/>
+		</properties>
+	</rule>
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<!-- Value: replace the text domain used. -->
+			<property name="text_domain" type="array" value="my-plugin"/>
+		</properties>
+	</rule>
+	<rule ref="WordPress.WhiteSpace.ControlStructureSpacing">
+		<properties>
+			<property name="blank_line_check" value="true"/>
+		</properties>
+	</rule>
+</ruleset>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,6 +1,12 @@
 <?xml version="1.0"?>
-<ruleset name="WordPress Coding Standards for Plugins">
-	<description>Generally-applicable sniffs for WordPress plugins</description>
+<ruleset name="Yikes Inc. Easy Mailchimp Extender">
+	<description>Rules for Yikes Inc. Easy Mailchimp Extender</description>
+
+	<arg name="extensions" value="php" />
+  <arg name="basepath" value="./" />
+  <file>./</file>
+	<arg name="colors"/>
+	<arg value="sp"/>
 
 	<rule ref="WordPress-Core">
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -2,9 +2,10 @@
 <ruleset name="Yikes Inc. Easy Mailchimp Extender">
 	<description>Rules for Yikes Inc. Easy Mailchimp Extender</description>
 
+	<file>./</file>
+
 	<arg name="extensions" value="php" />
   <arg name="basepath" value="./" />
-  <file>./</file>
 	<arg name="colors"/>
 	<arg value="sp"/>
 

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,49 +1,18 @@
 <?xml version="1.0"?>
-<ruleset name="WordPress Coding Standards based custom ruleset for your plugin">
-	<description>Generally-applicable sniffs for WordPress plugins.</description>
+<ruleset name="WordPress Coding Standards for Plugins">
+	<description>Generally-applicable sniffs for WordPress plugins</description>
 
-	<!-- What to scan -->
-	<file>.</file>
-	<exclude-pattern>/vendor/</exclude-pattern>
-	<exclude-pattern>/node_modules/</exclude-pattern>
+	<rule ref="WordPress-Core">
+		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
+		<exclude name="Squiz.PHP.CommentedOutCode.Found" />
+	</rule>
 
-	<!-- How to scan -->
-	<!-- Usage instructions: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
-	<!-- Annotated ruleset: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
-	<arg value="sp"/> <!-- Show sniff and progress -->
-	<arg name="basepath" value="./"/><!-- Strip the file paths down to the relevant bit -->
-	<arg name="colors"/>
-	<arg name="extensions" value="php"/>
-	<arg name="parallel" value="8"/><!-- Enables parallel processing when available for faster results. -->
+	<rule ref="WordPress-Extra">
+		<exclude name="WordPress.WhiteSpace.ControlStructureSpacing" />
+	</rule>
 
-	<!-- Rules: Check PHP version compatibility -->
-	<!-- https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
-	<config name="testVersion" value="5.3-"/>
-	<!-- https://github.com/PHPCompatibility/PHPCompatibilityWP -->
-	<rule ref="PHPCompatibilityWP"/>
-
-	<!-- Rules: WordPress Coding Standards -->
-	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
-	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
-	<config name="minimum_supported_wp_version" value="4.6"/>
-	<rule ref="WordPress">
-		<exclude name="WordPress.VIP"/>
-	</rule>
-	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
-		<properties>
-			<!-- Value: replace the function, class, and variable prefixes used. Separate multiple prefixes with a comma. -->
-			<property name="prefixes" type="array" value="my-plugin"/>
-		</properties>
-	</rule>
-	<rule ref="WordPress.WP.I18n">
-		<properties>
-			<!-- Value: replace the text domain used. -->
-			<property name="text_domain" type="array" value="my-plugin"/>
-		</properties>
-	</rule>
-	<rule ref="WordPress.WhiteSpace.ControlStructureSpacing">
-		<properties>
-			<property name="blank_line_check" value="true"/>
-		</properties>
-	</rule>
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/bin/*</exclude-pattern>
+	<exclude-pattern>*/tests/*</exclude-pattern>
+	<exclude-pattern>*/vendor/*</exclude-pattern>
 </ruleset>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,25 @@
+sudo: required
+
 language: php
 
-sudo: false
+dist: trusty
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
-  - 7.0
-  # https://hhvm.com/blog/2018/09/12/end-of-php-support-future-of-hack.html
-  #- hhvm
+  - 7.1
+  - 7.3
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0
+  - WP_VERSION=trunk WP_MULTISITE=0
   - WP_VERSION=4.9 WP_MULTISITE=0
   - WP_VERSION=4.6 WP_MULTISITE=0
-  - WP_VERSION=4.3 WP_MULTISITE=0
-  - WP_VERSION=4.0 WP_MULTISITE=0
+  - WP_VERSION=4.4 WP_MULTISITE=0
 
 matrix:
-  include:
-    - php: 5.3
-      dist: precise
-      env: WP_VERSION=4.9 WP_MULTISITE=0
-    - php: 5.4
-      env: WP_VERSION=latest WP_MULTISITE=1
   exclude:
-    # https://github.com/WordPress/wordpress-develop/commit/ce8a915c06c42ef4e65e26ce39c20e5029e80293
-    - php: 7.0
-      env: WP_VERSION=4.6 WP_MULTISITE=0
-    - php: 7.0
-      env: WP_VERSION=4.3 WP_MULTISITE=0
-    - php: 7.0
-      env: WP_VERSION=4.0 WP_MULTISITE=0
+    - php: 7.1
+      env: WP_VERSION=4.4 WP_MULTISITE=0
 
 before_script:
   - |
@@ -41,7 +29,7 @@ before_script:
 
 script:
   - |
-    if [[ "$TRAVIS_PHP_VERSION" == 5.5 && "$WP_VERSION" == latest && "$WP_MULTISITE" == 0 ]]; then
+    if [[ "$TRAVIS_PHP_VERSION" == 7.3 && "$WP_VERSION" == latest && "$WP_MULTISITE" == 0 ]]; then
         phpunit --coverage-clover=coverage.clover
     else
         phpunit
@@ -49,11 +37,11 @@ script:
 
 after_script:
   - |
-    if [[ "$TRAVIS_PHP_VERSION" == 5.5 && "$WP_VERSION" == latest && "$WP_MULTISITE" == 0 ]]; then
+    if [[ "$TRAVIS_PHP_VERSION" == 7.3 && "$WP_VERSION" == latest && "$WP_MULTISITE" == 0 ]]; then
         wget "https://scrutinizer-ci.com/ocular.phar"
     fi
   - |
-    if [[ "$TRAVIS_PHP_VERSION" == 5.5 && "$WP_VERSION" == latest && "$WP_MULTISITE" == 0 ]]; then
+    if [[ "$TRAVIS_PHP_VERSION" == 7.3 && "$WP_VERSION" == latest && "$WP_MULTISITE" == 0 ]]; then
         php ocular.phar code-coverage:upload --format=php-clover coverage.clover
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,9 @@ before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - |
     if [ -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini ]; then
-      phpenv config-rm xdebug.ini
+      if [[ "$TRAVIS_PHP_VERSION" != 7.3 ]]; then
+        phpenv config-rm xdebug.ini
+      fi
     else
       echo "xdebug.ini does not exist"
     fi
@@ -48,11 +50,11 @@ before_script:
 script:
   - |
     if [[ ! -z "$WP_VERSION" ]] ; then
-      if [[ "$TRAVIS_PHP_VERSION" == 7.3 && "$WP_VERSION" == latest ]]; then
-          phpunit --coverage-clover=coverage.clover
+      if [[ "$TRAVIS_PHP_VERSION" == 7.3 ]]; then
+        phpunit --coverage-clover=coverage.clover
       else
-          phpunit
-          WP_MULTISITE=1 phpunit
+        phpunit
+        WP_MULTISITE=1 phpunit
       fi
     fi
   - |
@@ -62,9 +64,9 @@ script:
 
 after_script:
   - |
-    if [[ "$TRAVIS_PHP_VERSION" == 7.3 && "$WP_VERSION" == latest ]]; then
-        wget "https://scrutinizer-ci.com/ocular.phar"
-        php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+    if [[ "$TRAVIS_PHP_VERSION" == 7.3 ]]; then
+      wget "https://scrutinizer-ci.com/ocular.phar"
+      php ocular.phar code-coverage:upload --format=php-clover coverage.clover
     fi
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,47 +1,72 @@
-sudo: required
+sudo: false
+dist: trusty
 
 language: php
 
-dist: trusty
-
-php:
-  - 5.6
-  - 7.1
-  - 7.3
-
-env:
-  - WP_VERSION=latest WP_MULTISITE=0
-  - WP_VERSION=trunk WP_MULTISITE=0
-  - WP_VERSION=4.9 WP_MULTISITE=0
-  - WP_VERSION=4.6 WP_MULTISITE=0
-  - WP_VERSION=4.4 WP_MULTISITE=0
+cache:
+  directories:
+    - $HOME/.composer/cache
 
 matrix:
-  exclude:
+  include:
+    - php: 7.3
+      env: WP_VERSION=latest
+    - php: 7.2
+      env: WP_VERSION=latest
     - php: 7.1
-      env: WP_VERSION=4.4 WP_MULTISITE=0
+      env: WP_VERSION=latest
+    - php: 7.0
+      env: WP_VERSION=latest
+    - php: 5.6
+      env: WP_VERSION=4.0
+    - php: 5.6
+      env: WP_VERSION=latest
+    - php: 5.6
+      env: WP_VERSION=trunk
+    - php: 5.6
+      env: WP_TRAVISCI=phpcs
+    - php: 5.3
+      env: WP_VERSION=latest
+      dist: precise
 
 before_script:
+  - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - |
-    phpunit --version
+    if [ -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini ]; then
+      phpenv config-rm xdebug.ini
+    else
+      echo "xdebug.ini does not exist"
+    fi
   - |
-    bash bin/install-wp-tests.sh wordpress_test root '' localhost "$WP_VERSION"
+    if [[ ! -z "$WP_VERSION" ]] ; then
+      bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
+      composer global require "phpunit/phpunit=4.8.*|5.7.*"
+    fi
+  - |
+    if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then
+      composer global require wp-coding-standards/wpcs
+      phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
+    fi
 
 script:
   - |
-    if [[ "$TRAVIS_PHP_VERSION" == 7.3 && "$WP_VERSION" == latest && "$WP_MULTISITE" == 0 ]]; then
-        phpunit --coverage-clover=coverage.clover
-    else
-        phpunit
+    if [[ ! -z "$WP_VERSION" ]] ; then
+      if [[ "$TRAVIS_PHP_VERSION" == 7.3 && "$WP_VERSION" == latest && "$WP_MULTISITE" == 0 ]]; then
+          phpunit --coverage-clover=coverage.clover
+      else
+          phpunit
+      fi
+      WP_MULTISITE=1 phpunit
+    fi
+  - |
+    if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then
+      phpcs
     fi
 
 after_script:
   - |
     if [[ "$TRAVIS_PHP_VERSION" == 7.3 && "$WP_VERSION" == latest && "$WP_MULTISITE" == 0 ]]; then
         wget "https://scrutinizer-ci.com/ocular.phar"
-    fi
-  - |
-    if [[ "$TRAVIS_PHP_VERSION" == 7.3 && "$WP_VERSION" == latest && "$WP_MULTISITE" == 0 ]]; then
         php ocular.phar code-coverage:upload --format=php-clover coverage.clover
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,6 @@ matrix:
       env: WP_VERSION=trunk
     - php: 5.6
       env: WP_TRAVISCI=phpcs
-    - php: 5.3
-      env: WP_VERSION=latest
-      dist: precise
 
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,12 +48,12 @@ before_script:
 script:
   - |
     if [[ ! -z "$WP_VERSION" ]] ; then
-      if [[ "$TRAVIS_PHP_VERSION" == 7.3 && "$WP_VERSION" == latest && "$WP_MULTISITE" == 0 ]]; then
+      if [[ "$TRAVIS_PHP_VERSION" == 7.3 && "$WP_VERSION" == latest ]]; then
           phpunit --coverage-clover=coverage.clover
       else
           phpunit
+          WP_MULTISITE=1 phpunit
       fi
-      WP_MULTISITE=1 phpunit
     fi
   - |
     if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then
@@ -62,7 +62,7 @@ script:
 
 after_script:
   - |
-    if [[ "$TRAVIS_PHP_VERSION" == 7.3 && "$WP_VERSION" == latest && "$WP_MULTISITE" == 0 ]]; then
+    if [[ "$TRAVIS_PHP_VERSION" == 7.3 && "$WP_VERSION" == latest ]]; then
         wget "https://scrutinizer-ci.com/ocular.phar"
         php ocular.phar code-coverage:upload --format=php-clover coverage.clover
     fi

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,8 +7,16 @@
 	convertWarningsToExceptions="true"
 	>
 	<testsuites>
-		<testsuite>
+		<testsuite name="Yikes Inc. Easy Mailchimp Extender Test Suite">
 			<directory prefix="test-" suffix=".php">./tests/</directory>
 		</testsuite>
 	</testsuites>
+	<filter>
+		<whitelist addUncoveredFilesFromWhitelist="true">
+			<directory>./admin</directory>
+			<directory>./blocks</directory>
+			<directory>./includes</directory>
+			<directory>./public</directory>
+		</whitelist>
+	</filter>
 </phpunit>


### PR DESCRIPTION
Hey @freddiemixell - great meeting you in person and chatting a bit at WordCamp US! 💯 

This issue crossed my mind the other day and I thought I'd check in and see if things were ever fixed up. I've put together this PR (since we didn't have a chance to get to fix this at contributor day). This should fix up the Travis builds, and update a few things.

I've introduced a PHPCS configuration file and added PHPCS to the PHP 5.6 travis builds, so the files are scanned and WordPress coding standards are enforced. You'll need to clean up those PHPCS warnings before the Travis builds pass.

#### PHPCS Warnings/Errors:
https://travis-ci.com/EvanHerman/yikes-inc-easy-mailchimp-extender/jobs/257469036

#### Latest Test Run:
https://travis-ci.com/EvanHerman/yikes-inc-easy-mailchimp-extender