### PR TITLE
Add/headers filter

### DIFF
--- a/includes/api/class-yikes-inc-easy-mailchimp-api.php
+++ b/includes/api/class-yikes-inc-easy-mailchimp-api.php
@@ -185,6 +185,7 @@ class Yikes_Inc_Easy_Mailchimp_API {
 	 * @return array|WP_Error
 	 */
 	protected function send_request( $path, $method, $headers = array(), $params = array() ) {
+		$headers = apply_filters( 'yikesinc_eme_mailchimp_headers', $headers );
 
 		// Remove leading slashes from $path, as we'll add that ourselves later.
 		$path = ltrim( $path, '/' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yikes-inc-easy-mailchimp-extender",
-  "version": "6.6.3",
+  "version": "6.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yikes-inc-easy-mailchimp-extender",
-  "version": "6.6.3",
+  "version": "6.4.0",
   "devDependencies": {
     "@wordpress/scripts": "^5.1.0",
     "braces": ">=2.3.1",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: yikesinc, eherman24, liljimmi, JPry, yikesitskevin, fmixell
 Donate link: https://yikesplugins.com/?utm_source=wp_plugin_repo&utm_medium=donate_link&utm_campaign=easy_forms_for_mailchimp
 Tags: Mailchimp, Mailchimp forms, Mailchimp lists, opt-in forms, sign up form, Mailchimp, email, forms, mailing lists, marketing, newsletter, sign up
 Requires at least: 4.0
-Tested up to: 5.3
+Tested up to: 5.4
 Requires PHP: 5.2.13
 Stable tag: 6.4.0
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: Mailchimp, Mailchimp forms, Mailchimp lists, opt-in forms, sign up form, M
 Requires at least: 4.0
 Tested up to: 5.3
 Requires PHP: 5.2.13
-Stable tag: 6.6.3
+Stable tag: 6.4.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -172,6 +172,10 @@ For information and code examples on how to implement the hooks and filters prov
 
 == Changelog ==
 
+= 6.4.0 - June 15th, 2020 =
+* New filter: yikesinc_eme_mailchimp_headers filters the Mailchimp API headers.
+* This allows users to filter the api request to send specific language responses to users.
+
 = 6.6.3 - February, 27, 2020 =
 * Important security release.
 

--- a/yikes-inc-easy-mailchimp-extender.php
+++ b/yikes-inc-easy-mailchimp-extender.php
@@ -3,7 +3,7 @@
  * Plugin Name: Easy Forms for Mailchimp
  * Plugin URI:  https://yikesplugins.com/plugin/easy-forms-for-mailchimp/
  * Description: The ultimate Mailchimp WordPress plugin. Easily build <strong>unlimited forms for your Mailchimp lists</strong>, add them to your site and track subscriber activity. To get started, go to the settings page and enter your <a href="https://yikesplugins.com/support/knowledge-base/finding-your-mailchimp-api-key/" target="_blank">Mailchimp API key</a>.
- * Version:     6.6.3
+ * Version:     6.4.0
  * Author:      YIKES, Inc.
  * Author URI:  https://www.yikesplugins.com/
  * License:     GPL-3.0+
@@ -43,7 +43,7 @@ if ( ! defined( 'WPINC' ) ) {
  * 	@since 6.1.3
  */
 if ( ! defined( 'YIKES_MC_VERSION' ) ) {
-	define( 'YIKES_MC_VERSION', '6.6.3' );
+	define( 'YIKES_MC_VERSION', '6.4.0' );
 }
 
 /**


### PR DESCRIPTION
Adds  a filter for the headers that are sent with the request to Mailchimp. This allows users of the plugin to filter those headers to pass extra information along to Mailchimp.

Here's an example use case: https://wordpress.org/support/topic/pass-language-on-to-mailchimp/

Person wants to pass the browsers language along to Mailchimp so Mailchimp can send out an email appropriately.

```
add_action( 'yikesinc_eme_mailchimp_headers', 'yikes_send_accept_language' );

function yikes_send_accept_language( $headers = array() ) {
	if ( isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ) {
		$headers['Accept-Language'] = $_SERVER['HTTP_ACCEPT_LANGUAGE'];
	}
	return $headers;
}
```

