### PR TITLE
Fix PHP 8.0 Fatal Errors when there are no forms available

### DIFF
--- a/admin/partials/menu/manage-forms.php
+++ b/admin/partials/menu/manage-forms.php
@@ -128,7 +128,7 @@ if( $this->is_user_mc_api_valid_form( false ) == 'valid' ) {
 								<!-- TABLE BODY -->
 								<tbody>
 									<?php
-									if ( count( $all_forms ) > 0 ) {
+									if ( $all_forms && count( $all_forms ) > 0 ) {
 										$i = 1;
 										foreach( $all_forms as $id => $form ) {
 										?>

--- a/includes/class-yikes-inc-easy-mailchimp-extender-option-forms.php
+++ b/includes/class-yikes-inc-easy-mailchimp-extender-option-forms.php
@@ -31,10 +31,14 @@ class Yikes_Inc_Easy_Mailchimp_Extender_Option_Forms extends Yikes_Inc_Easy_Mail
 	 * Get the IDs of all registered forms.
 	 *
 	 * @author Jeremy Pry
-	 * @return array All form IDs.
+	 * @return array|bool All form IDs.
 	 */
 	public function get_form_ids() {
-		return array_keys( $this->get_all_forms() );
+		if ( is_array( $this->get_all_forms() ) ) {
+			return array_keys( $this->get_all_forms() );
+		}
+
+		return false;
 	}
 
 	/**
@@ -77,7 +81,12 @@ class Yikes_Inc_Easy_Mailchimp_Extender_Option_Forms extends Yikes_Inc_Easy_Mail
 
 		// Grab our existing IDs and determine what the next one should be.
 		$all_ids         = $this->get_form_ids();
-		$last_id         = end( $all_ids );
+		$last_id         = 0;
+
+		if ( is_array( $all_ids ) ) {
+			$last_id = end( $all_ids );
+		}
+
 		$new_id          = false === $last_id ? 1 : $last_id + 1;
 		$form_data['id'] = $new_id;
 


### PR DESCRIPTION
Some small fixes to avoid errors in PHP 8.0 when there are no forms available.
https://wordpress.org/support/topic/two-fatal-errors-in-php-8-fixes/