### PR TITLE
Fix PHP 8: declare required args before optional args

### DIFF
--- a/public/helpers.php
+++ b/public/helpers.php
@@ -11,7 +11,7 @@
 *	
 *	@since 6.0.0
 */
-function yksemeProcessSnippet( $list=false, $submit_text ) {
+function yksemeProcessSnippet( $submit_text, $list=false ) {
 	$submit_text = ( isset( $submit_text ) ) ? 'submit="' . $submit_text . '"' : '';
 	return do_shortcode( '[yikes-mailchimp form="' . $list . '" ' . $submit_text . ']' );
 }


### PR DESCRIPTION
Fixes PHP deprecation in v8.0.0.
`PHP Deprecated:  Required parameter $submit_text follows optional parameter $list in yikes-inc-easy-mailchimp-extender/public/helpers.php on line 14`

More about function arguments: https://www.php.net/manual/en/functions.arguments.php